### PR TITLE
[bugfix] Coerce all moves to be 0 or 1

### DIFF
--- a/code/prisonersDilemma.py
+++ b/code/prisonersDilemma.py
@@ -33,7 +33,7 @@ def strategyMove(move):
         defects = ["defect","tell truth"]
         return 0 if (move in defects) else 1
     else:
-        return move
+        return int(bool(move))
 
 def runRound(pair):
     moduleA = importlib.import_module(STRATEGY_FOLDER+"."+pair[0])

--- a/code/prisonersDilemma.py
+++ b/code/prisonersDilemma.py
@@ -33,6 +33,7 @@ def strategyMove(move):
         defects = ["defect","tell truth"]
         return 0 if (move in defects) else 1
     else:
+        # Coerce all moves to be 0 or 1 so strategies can safely assume 0/1's only
         return int(bool(move))
 
 def runRound(pair):


### PR DESCRIPTION
Fixes #44 

In `strategyMove()`, strings are parsed as 0 or 1 but non-string inputs that are not 0 or 1 are just parsed as themselves. This can mess with strategies (via silent defections) and/or create run-time errors. E.g., if a strategy looks like:

```
def strategy(history, memory):
    ...
    if history[1, -1] == 0:
        some_var = True
    if history[1, -1] == 1:
        some_var = False
    do_something(some_var)
    ...
```

and another strategy in the mix returns numeric results that *aren't* 1 or 0 (like in #44):
```
def strategy(history, memory): return -2, None
```

Running `prisonersDilemma.py` will throw a:
```
UnboundLocalError: local variable 'some_var' referenced before assignment
```

This single-commit one-liner PR fixes that by coercing all moves to be 0 or 1 by using Python's "truthy" and "falsy" values. All "falsy" values (other than string ones, which your code already handles) become 0, all "truthy" values become 1. You can no longer throw off opponents by returning 2, -2, 3.141592653589793238462643..., etc.