### PR TITLE
Restricting return values

### DIFF
--- a/code/prisonersDilemma.py
+++ b/code/prisonersDilemma.py
@@ -33,7 +33,7 @@ def strategyMove(move):
         defects = ["defect","tell truth"]
         return 0 if (move in defects) else 1
     else:
-        return move
+        return int(bool(move)) # Clamping move to 0 or 1 based off of truthiness
 
 def runRound(pair):
     moduleA = importlib.import_module(STRATEGY_FOLDER+"."+pair[0])


### PR DESCRIPTION
Fixes #44 where strategies can return values that have ambiguous truthiness to mess up other strategies.

Should allow for the normal 0 and 1, the specific strings, or other common values such as False and True.