### PR TITLE
Reload to clear module-level variables between games

### DIFF
--- a/code/prisonersDilemma.py
+++ b/code/prisonersDilemma.py
@@ -39,6 +39,8 @@ def strategyMove(move):
 def runRound(pair):
     moduleA = importlib.import_module(STRATEGY_FOLDER+"."+pair[0])
     moduleB = importlib.import_module(STRATEGY_FOLDER+"."+pair[1])
+    importlib.reload(moduleA)
+    importlib.reload(moduleB)
     memoryA = None
     memoryB = None
     


### PR DESCRIPTION
Mitigates #58 by forcing to `reload` the module and reset its global variables (See https://docs.python.org/3/library/importlib.html#importlib.reload)

Confirmed that this fix makes the code in #58 no longer work.

However, there are still ways to get around, and I don't think a complete fix is possible. To prevent this completely we may have to rely on manual inspection.